### PR TITLE
update apple silicon gcc/clang mtune=native logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,12 +81,9 @@ endif()
 # --------------------------------------------------------------------
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
-	    if( ( "${APPLE_CPU_MODEL}" MATCHES "M1|M2" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.1 )
-		    OR ( "${APPLE_CPU_MODEL}" STREQUAL "M3" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.1 ) )
-		    list(APPEND OPT_CFLAGS "-O2" "-mtune=native")
-	    else()
-		    list(APPEND OPT_CFLAGS "-O2")
-	    endif()
+        # switch off mtune - it must be supported by the underlying clang compiler
+        # we have no way of checking for compatible gnu/clang versions here
+        list(APPEND OPT_CFLAGS "-O2")
     else()
         list(APPEND OPT_CFLAGS "-O2" "-mtune=native")
     endif()
@@ -106,14 +103,11 @@ endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
-	    if( ( "${APPLE_CPU_MODEL}" MATCHES "M1|M2" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.1 )
-		    OR ( "${APPLE_CPU_MODEL}" STREQUAL "M3" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.1 ) )
-		    list(APPEND OPT_CXXFLAGS "-O2" "-mtune=native")
-	    else()
-		    list(APPEND OPT_CXXFLAGS "-O2")
-	    endif()
+        # switch off mtune - it must be supported by the underlying clang compiler
+        # we have no way of checking for compatible gnu/clang versions here
+        list(APPEND OPT_CXXFLAGS "-O2")
     else()
-	    list(APPEND OPT_CXXFLAGS "-O2" "-mtune=native")
+        list(APPEND OPT_CXXFLAGS "-O2" "-mtune=native")
     endif()
 
     if (WARNINGS)
@@ -137,16 +131,26 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif()
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
-	    if( ( "${APPLE_CPU_MODEL}" MATCHES "M1|M2" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.1.0 )
-		    OR ( "${APPLE_CPU_MODEL}" STREQUAL "M3" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.1.0 ) )
-		    list(APPEND OPT_FFLAGS "-O2" "-mtune=native")
-	    else()
-		    # workaround GCC code generation issues with M3 and newer CPUs
-		    list(APPEND OPT_FFLAGS "-O2")
-	    endif()
+
+        if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+            if( ( "${APPLE_CPU_MODEL}" MATCHES "M1" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0.0 )
+                OR  ( "${APPLE_CPU_MODEL}" MATCHES "M2" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 16.0.0 )
+                OR  ( "${APPLE_CPU_MODEL}" MATCHES "M3" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0.0 )
+                OR  ( "${APPLE_CPU_MODEL}" MATCHES "M4" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 20.1.0 ) )
+                list(APPEND OPT_FFLAGS "-O2" "-mtune=native")
+            else()
+                list(APPEND OPT_FFLAGS "-O2")
+            endif()
+        else()
+            # switch off mtune - it must be supported by the underlying clang compiler
+            # we are using GNU C/C++ compiler and have no way of checking for compatible gnu/clang versions here
+            list(APPEND OPT_FFLAGS "-O2")
+        endif()
+
     else()
-	    list(APPEND OPT_FFLAGS "-O2" "-mtune=native")
+        list(APPEND OPT_FFLAGS "-O2" "-mtune=native")
     endif()
 
     add_flags(Fortran -ffree-line-length-none)


### PR DESCRIPTION
Disable mtune=native for GNU compilers
- if using both GNU C/C++ and GNU Fortran compilers (cannot check for compatible clang version)
- for GNU Fortran if using incompatible clang C/C++ compilers